### PR TITLE
fix invalid cf port

### DIFF
--- a/code/03_wire_standards/stomp/src/main/resources/jndi.properties
+++ b/code/03_wire_standards/stomp/src/main/resources/jndi.properties
@@ -1,3 +1,3 @@
 java.naming.factory.initial=org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory
-connectionFactory.ConnectionFactory=tcp://localhost:71728
+connectionFactory.ConnectionFactory=tcp://localhost:61616
 queue.queue/gpteQueue=gpteQueue


### PR DESCRIPTION
The connection factory port is invalid (>65k) so the JMS consumer won't work. I changed it to the default port for AMQ, since the course I was following which uses this project uses default acceptors.